### PR TITLE
feat: move chat history into toggleable panel

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -208,40 +208,6 @@ export default function Dashboard() {
             })}
 
             {/* Removed "Today’s Energy" section for now */}
-
-            {/* Conversations: visible only on the "Chat with Beatrice" page */}
-            {activeSection === 'chat' && (
-              <div className="mt-6 p-4 bg-white dark:bg-gray-800 rounded-lg border border-purple-100 dark:border-purple-800">
-                <div className="flex items-center justify-between mb-3">
-                  <h3 className="text-sm font-semibold text-gray-800 dark:text-gray-200">Conversations</h3>
-                  <button
-                    onClick={() => setInitialConversationId(undefined)}
-                    className="text-xs px-2 py-1 rounded bg-purple-600 text-white hover:bg-purple-700"
-                    title="Start a new conversation"
-                  >
-                    New
-                  </button>
-                </div>
-                <div className="space-y-1 max-h-64 overflow-auto">
-                  {conversations.length === 0 && (
-                    <p className="text-xs text-gray-500 dark:text-gray-400">No conversations yet</p>
-                  )}
-                  {conversations.map((c) => (
-                    <button
-                      key={c.id}
-                      onClick={() => setInitialConversationId(c.id)}
-                      className={`w-full text-left px-3 py-2 rounded hover:bg-purple-100 dark:hover:bg-purple-900/50 ${initialConversationId === c.id ? 'bg-purple-100 dark:bg-purple-900/40' : ''}`}
-                      title={c.title || 'Untitled conversation'}
-                    >
-                      <p className="text-sm font-medium text-gray-800 dark:text-gray-200 truncate">{c.title || 'Untitled conversation'}</p>
-                      <p className="text-[10px] text-gray-500 dark:text-gray-400">
-                        {new Date(c.last_message_at || c.created_at || '').toLocaleString()}
-                      </p>
-                    </button>
-                  ))}
-                </div>
-              </div>
-            )}
           </nav>
         </div>
 
@@ -264,6 +230,9 @@ export default function Dashboard() {
                     setConversations(updated || []);
                   })();
                 }}
+                conversations={conversations}
+                onSelectConversation={(id) => setInitialConversationId(id)}
+                onNewConversation={() => setInitialConversationId(undefined)}
               />
             </div>
           )}


### PR DESCRIPTION
## Summary
- Make ChatInterface accept conversations and expose controls to load or start chats
- Toggleable chat history panel replaces sidebar conversation list
- Update dashboard to pass conversation data to ChatInterface

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6899d4e12f5483218e5c9e834f6a329b