### PR TITLE
fix: use MapIcon in dashboard navigation

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -8,7 +8,7 @@ import ChatInterface from '../components/chat/ChatInterface';
 import {
   Sparkles, Moon, BookOpen, Compass,
   Heart, LogOut, Menu, X,
-  Feather, Map,
+  Feather, Map as MapIcon,
   type LucideIcon,
 } from 'lucide-react';
 import type { User } from '@supabase/supabase-js';
@@ -133,7 +133,7 @@ export default function Dashboard() {
 
   const navigationItems: NavigationItem[] = [
     { id: 'chat', icon: Sparkles, label: 'Chat with Beatrice', badge: null },
-    { id: 'journey', icon: Map, label: 'Spiritual Journey', href: '/dashboard/spiritual-journey', badge: null },
+    { id: 'journey', icon: MapIcon, label: 'Spiritual Journey', href: '/dashboard/spiritual-journey', badge: null },
     { id: 'journal', icon: Feather, label: 'Journal', badge: 'Coming Soon' },
     { id: 'rituals', icon: Sparkles, label: 'Rituals', badge: 'Coming Soon' },
     { id: 'grimoire', icon: BookOpen, label: 'Grimoire', badge: 'Coming Soon' },


### PR DESCRIPTION
## Summary
- alias lucide-react Map as MapIcon
- use MapIcon for spiritual journey navigation entry

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899ddef8b00832191c09c7426d8dab1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Style
  * Updated the "Spiritual Journey" item in the dashboard navigation to use a map-style icon for clearer visual association.
  * Improved overall icon consistency within the dashboard, enhancing quick recognition and wayfinding.
  * No changes to behavior or data; this is a visual refinement only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->