### PR TITLE
fix: sanitize login redirect parameter

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -7,7 +7,7 @@ import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
 export default async function LoginPage({
   searchParams
 }: {
-  searchParams: Promise<{ returnTo?: string }>
+  searchParams: { returnTo?: string }
 }) {
   const supabase = createServerComponentClient({ cookies })
   const {
@@ -18,9 +18,26 @@ export default async function LoginPage({
     redirect('/dashboard')
   }
 
-  const params = await searchParams
-  const returnTo = params.returnTo ? decodeURIComponent(params.returnTo) : undefined
+  const decoded = (() => {
+    if (!searchParams.returnTo) return undefined
+    try {
+      return decodeURIComponent(searchParams.returnTo)
+    } catch {
+      return undefined
+    }
+  })()
+  const returnTo = sanitizeReturnTo(decoded)
   return <LoginForm returnTo={returnTo} />
+}
+
+function sanitizeReturnTo(returnTo?: string): string | undefined {
+  if (typeof returnTo !== 'string') return undefined
+  if (!returnTo.startsWith('/')) return '/'
+  if (returnTo.startsWith('//')) return '/'
+  if (returnTo.includes('://')) return '/'
+  if (returnTo.includes('\\')) return '/'
+  const safePathRegex = /^\/[A-Za-z0-9\-._~\/]*$/
+  return safePathRegex.test(returnTo) ? returnTo : '/'
 }
 
 // Add metadata for the page


### PR DESCRIPTION
## Summary
- remove Promise from login page searchParams and add return path sanitizer

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899dd6f89ec8321828b6ea31762d8b7